### PR TITLE
Update: Twitter API GET URL to v2

### DIFF
--- a/modules/services/twitter.js
+++ b/modules/services/twitter.js
@@ -4,7 +4,7 @@ var deferred = require('deferred');
 exports.fetch = function(urls, metrics) {
 	return deferred.map(urls, function(url) {
 		var def = deferred();
-		req.get("http://urls.api.twitter.com/1/urls/count.json?url="+encodeURIComponent(url), function(err, respobj, resp) {
+		req.get("http://urls.api.twitter.com/2/urls/count.json?url="+encodeURIComponent(url), function(err, respobj, resp) {
 			try {
 				resp = JSON.parse(resp);
 				def.resolve({url:url, metric:'shares', count:resp.count});


### PR DESCRIPTION
cc @commuterjoy  @TheoLeanse 

Twitter seem to have turned off v1 of their API URL (returns nothing whatsoever while v2 returns error 34). This won't fix counts not being displayed for respective social network icons on article pages but will remedy the console error in the meantime.
